### PR TITLE
fix: httpx.LocalProtocolError: Invalid input

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -61,6 +61,8 @@ def main():
         .token(config.telegram_token)
         .post_init(post_init)
         .persistence(persistence)
+        .get_updates_http_version('1.1')
+        .http_version('1.1')
         .build()
     )
 


### PR DESCRIPTION
I saw there errors before, but It didn't bother me. 
```
pokitoki    | 2023-03-23 10:41:58,445 ERROR telegram.ext._updater Error while getting Updates: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED
pokitoki    | 2023-03-23 10:41:58,446 ERROR main General exception: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED:
pokitoki    | 2023-03-23 10:41:59,954 ERROR telegram.ext._updater Error while getting Updates: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED
pokitoki    | 2023-03-23 10:41:59,956 ERROR main General exception: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED:
pokitoki    | 2023-03-23 10:42:02,215 ERROR telegram.ext._updater Error while getting Updates: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED
pokitoki    | 2023-03-23 10:42:02,216 ERROR main General exception: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED:
pokitoki    | 2023-03-23 10:42:05,598 ERROR telegram.ext._updater Error while getting Updates: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED
pokitoki    | 2023-03-23 10:42:05,599 ERROR main General exception: httpx.LocalProtocolError: Invalid input ConnectionInputs.SEND_HEADERS in state ConnectionState.CLOSED:
```

Over time, the bot occasionally did not work, and I began to receive error messages stating `Failed to answer. Reason: Request timed out`.

I followed instructions from [this issue ](https://github.com/python-telegram-bot/python-telegram-bot/issues/3556)and it helps me
