### PR TITLE
Allow building docker image to not 64bit targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /code
+# tiktoken comes precompiled only for 64 bit targets.
+# On other targets we have to compile it with rust
+RUN grep -q 64 /etc/apk/arch || { \
+    apk add cargo rust && \
+    rm /var/cache/apk/* ; }
 COPY ./requirements.txt .
 RUN pip3 install -r requirements.txt
 


### PR DESCRIPTION
tiktoken dependency [comes precompiled](https://pypi.org/project/tiktoken/#files) only for 64bit targets
On other targets we need to compile it with rust.

------
For the context. At my setup original docker image used 3% of RAM and 0.06% of available CPU power. So it makes total sense to reduce RAM consumption at probable cost of extra CPU usage.

Just replacing `python:3.11-alpine` with `docker.io/i386/python:3.11-alpine` in FROM clause was not enough, I had to add rust. Eventually I succeeded: RAM usage reduced by 30% with no significant change of CPU usage.

Unfortunately though installing cargo and rust and recimpiling tiktoken inflates resulting image up to 1.2 GiB.